### PR TITLE
Fix on large machines (more than 16 GB)

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -1,11 +1,51 @@
-/*
- *  Created: 7/25/2019 11:27 AM
- *  Author: jaredmeister
- */
-public class Main
-{
-    public static void main(String a[])
-    {
-        long[] outOfMemory = new long[Integer.MAX_VALUE];
-    }
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+
+public class Main {
+
+	public static void main(String[] args) {
+		args = new String[] { "direct" };
+		if (args.length == 0) {
+			System.out.println("Usage: [direct / heap]");
+			System.exit(1);
+		}
+		String mode = args[0].toLowerCase();
+		boolean useDirect = mode.equals("direct");
+		if (!useDirect && !mode.equals("heap")) {
+			System.out.println("Usage: [direct / heap]");
+			System.exit(1);
+		}
+		System.out.println("Starting...");
+		ArrayList<ByteBuffer> list = new ArrayList<>();
+		int x = 1;
+		while (true) {
+			list.add(randomize(useDirect ? ByteBuffer.allocateDirect(x) : ByteBuffer.allocate(x)));
+			if (x != Integer.MAX_VALUE) {
+				x <<= 1;
+			}
+			if (x < 0) {
+				x = Integer.MAX_VALUE;
+			}
+		}
+	}
+
+	private static ByteBuffer randomize(ByteBuffer bb) {
+		if (bb.hasArray()) {
+			nextBytes(bb.array());
+		} else {
+			while (bb.hasRemaining()) {
+				byte[] b = new byte[Math.min(1024, bb.remaining())];
+				nextBytes(b);
+				bb.put(b);
+			}
+		}
+		return bb;
+	}
+
+	private static void nextBytes(byte[] b) {
+		for (int i = 0; i < b.length; i++) {
+			b[i] = (byte) i;
+		}
+	}
+
 }


### PR DESCRIPTION
I've more than 16 GB RAM and your version doesn't create an out of memory exception, so I enhanced it and added support for direct allocating. Filling bytes is needed because some OS can compress memory or detect unused allocation.